### PR TITLE
Removed generic from ReloadFromDataProviderSources.

### DIFF
--- a/MN.L10n.BuildTasks/MN.L10n.BuildTasks.csproj
+++ b/MN.L10n.BuildTasks/MN.L10n.BuildTasks.csproj
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <StartupObject>MN.L10n.BuildTasks.Program</StartupObject>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.44</Version>
+    <Version>1.0.45</Version>
     <Authors>Chris Gårdenberg</Authors>
     <Company>MultiNet Interactive AB</Company>
     <AssemblyVersion>1.0.43</AssemblyVersion>

--- a/MN.L10n.BuildTasks/MN.L10n.BuildTasks.csproj
+++ b/MN.L10n.BuildTasks/MN.L10n.BuildTasks.csproj
@@ -11,6 +11,7 @@
     <Company>MultiNet Interactive AB</Company>
     <AssemblyVersion>1.0.43</AssemblyVersion>
     <FileVersion>1.0.43.0</FileVersion>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net462|AnyCPU'">

--- a/MN.L10n.BuildTasks/Program.cs
+++ b/MN.L10n.BuildTasks/Program.cs
@@ -88,7 +88,7 @@ namespace MN.L10n.BuildTasks
                 if(config.DownloadTranslationFromSourcesOnBuild)
                 {
                     Console.WriteLine("info l10n: Loading translations from sources defined in languages.json");
-                    var fdp = L10n.GetDataProvider<FileDataProvider>();
+                    var fdp = L10n.GetDataProvider();
                     if (fdp != null)
                     {
                         try

--- a/MN.L10n.Tests/MN.L10n.Tests.csproj
+++ b/MN.L10n.Tests/MN.L10n.Tests.csproj
@@ -39,6 +39,10 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FakeItEasy, Version=5.0.0.0, Culture=neutral, PublicKeyToken=eff28e2146d5fd2c">
+      <HintPath>..\packages\FakeItEasy.5.1.1\lib\net45\FakeItEasy.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.1.3.2\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
@@ -49,8 +53,10 @@
     <Reference Include="System.Core" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="NullDataProviderTests.cs" />
     <Compile Include="ParserTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="StaticL10nTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MN.L10n\MN.L10n.csproj">

--- a/MN.L10n.Tests/NullDataProviderTests.cs
+++ b/MN.L10n.Tests/NullDataProviderTests.cs
@@ -1,0 +1,34 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using MN.L10n.NullProviders;
+
+namespace MN.L10n.Tests
+{
+    [TestClass]
+    public class NullDataProviderTests
+    {   
+        [TestMethod]
+        public void LoadL10n()
+        {
+            var provider = CreateNullProvider();
+            var l10n = provider.LoadL10n();
+            Assert.AreEqual(0, l10n.Phrases.Count);
+            Assert.AreEqual(1, l10n.Languages.Count);
+        }
+
+        [TestMethod]
+        public async Task ReloadFromSources()
+        {
+            var provider = CreateNullProvider();
+            var l10n = provider.LoadL10n();
+            var reloaded = await provider.LoadTranslationFromSources(l10n, CancellationToken.None);
+            Assert.IsFalse(reloaded);
+        }
+        
+        private NullDataProvider CreateNullProvider()
+        {
+            return new NullDataProvider();
+        }
+    }
+}

--- a/MN.L10n.Tests/StaticL10nTests.cs
+++ b/MN.L10n.Tests/StaticL10nTests.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using FakeItEasy;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MN.L10n.Tests
+{
+    [TestClass]
+    public class StaticL10nTests
+    {   
+        [TestMethod]
+        public async Task ReloadFromSourceNotInitialized()
+        {
+            try
+            {
+                await L10n.ReloadFromDataProviderSources(CancellationToken.None);
+                Assert.Fail("Not initialized exception expected");
+            }
+            catch (Exception ex)
+            {
+                if (ex.Message == null || !ex.Message.Contains("L10n.CreateInstance"))
+                {
+                    throw;
+                }
+            }
+        }
+
+        [TestMethod]
+        public async Task ReloadFromSources()
+        {
+            CreateFakes();
+            var reloaded = await L10n.ReloadFromDataProviderSources(CancellationToken.None);
+            Assert.IsFalse(reloaded);
+        }
+
+        [TestMethod]
+        public async Task ReloadFromSources2()
+        {
+            var fakes = CreateFakes();
+            A.CallTo(() => fakes.DataProvider.LoadTranslationFromSources(fakes.L10n, CancellationToken.None))
+                .Returns(Task.FromResult(true));
+            var reloaded = await L10n.ReloadFromDataProviderSources(CancellationToken.None);
+            Assert.IsTrue(reloaded);
+        }
+
+        [TestMethod]
+        public async Task ReloadFromSourcesDoesNotCallHookWhenReloadFails()
+        {
+            CreateFakes();
+            L10n.TranslationsReloaded += (sender, args) => Assert.Fail("Unexpected call to reloaded hook"); 
+            await L10n.ReloadFromDataProviderSources(CancellationToken.None);
+        }
+
+        [TestMethod]
+        public async Task ReloadFromSourceCallsHookWhenReloadSucceeds()
+        {
+            var fakes = CreateFakes();
+            A.CallTo(() => fakes.DataProvider.LoadTranslationFromSources(fakes.L10n, CancellationToken.None))
+                .Returns(Task.FromResult(true));
+            var hookWasCalled = false;
+            L10n.TranslationsReloaded += (sender, args) => hookWasCalled = true; 
+            await L10n.ReloadFromDataProviderSources(CancellationToken.None);
+            Assert.IsTrue(hookWasCalled, "Translations reloaded was not called");
+        }
+
+        [TestMethod]
+        public async Task RemoveTranslationReloadedListeners()
+        {
+            var fakes = CreateFakes();
+            L10n.TranslationsReloaded += (sender, args) => Assert.Fail("Unexpected call to reloaded hook"); 
+            A.CallTo(() => fakes.DataProvider.LoadTranslationFromSources(fakes.L10n, CancellationToken.None))
+                .Returns(Task.FromResult(true));
+            
+            L10n.RemoveAllTranslationReloadedListeners();
+            await L10n.ReloadFromDataProviderSources(CancellationToken.None);
+        }
+        
+        private class Fakes
+        {
+            public L10n L10n { get; set; }
+            public IL10nLanguageProvider LanguageProvider { get; }
+            public IL10nDataProvider DataProvider { get; }
+
+            public Fakes()
+            {
+                LanguageProvider = A.Fake<IL10nLanguageProvider>();
+                DataProvider = A.Fake<IL10nDataProvider>();
+            }
+        }
+
+        private Fakes CreateFakes()
+        {
+            var fakes = new Fakes();
+            var l10n = L10n.CreateInstance(fakes.LanguageProvider, fakes.DataProvider);
+            fakes.L10n = l10n;
+            return fakes;
+        }
+        
+        [TestCleanup]
+        public void CleanupTests()
+        {
+            L10n.RemoveAllTranslationReloadedListeners();
+        }
+    }
+}

--- a/MN.L10n.Tests/packages.config
+++ b/MN.L10n.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="FakeItEasy" version="5.1.1" targetFramework="net472" />
   <package id="MSTest.TestAdapter" version="1.3.2" targetFramework="net471" />
   <package id="MSTest.TestFramework" version="1.3.2" targetFramework="net471" />
 </packages>

--- a/MN.L10n/FileProviders/FileDataProvider.cs
+++ b/MN.L10n/FileProviders/FileDataProvider.cs
@@ -125,12 +125,12 @@ namespace MN.L10n.FileProviders
             return true;
         }
 
-        public async Task LoadTranslationFromSources(L10n l10n, CancellationToken token)
+        public async Task<bool> LoadTranslationFromSources(L10n l10n, CancellationToken token)
         {
             bool errorLoadingSources = false;
             Exception _ex = null;
             // If we don't have anything to fetch from any sources, don't bother
-            if (!l10n.Languages.Any(l => l.Sources.Any())) return;
+            if (!l10n.Languages.Any(l => l.Sources.Any())) return false;
 
             using (var cli = new HttpClient())
             {
@@ -198,6 +198,7 @@ namespace MN.L10n.FileProviders
             }
 
             SaveL10n(l10n);
+            return true;
         }
     }
 }

--- a/MN.L10n/IL10nDataProvider.cs
+++ b/MN.L10n/IL10nDataProvider.cs
@@ -8,6 +8,6 @@ namespace MN.L10n
 		L10n LoadL10n();
 		bool SaveL10n(L10n l10n);
 
-        Task LoadTranslationFromSources(L10n l10n, CancellationToken token);
+        Task<bool> LoadTranslationFromSources(L10n l10n, CancellationToken token);
     }
 }

--- a/MN.L10n/MN.L10n.csproj
+++ b/MN.L10n/MN.L10n.csproj
@@ -12,13 +12,13 @@ Translation package</Description>
     <PackageProjectUrl>https://github.com/MultinetInteractive/MN.L10n</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <Copyright>© 20XX MultiNet Interactive AB</Copyright>
-    <Version>1.1.10</Version>
+    <Version>1.2.0</Version>
 	<AutoIncrementPackageRevision>True</AutoIncrementPackageRevision>
 	<PackageReleaseNotes>Now includes analyzer</PackageReleaseNotes>
 	<ApplicationIcon />
 	<OutputType>Library</OutputType>
 	<StartupObject></StartupObject>
-	<AssemblyVersion>1.1.10.0</AssemblyVersion>
+	<AssemblyVersion>1.2.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/MN.L10n/NullProviders/NullDataProvider.cs
+++ b/MN.L10n/NullProviders/NullDataProvider.cs
@@ -16,9 +16,9 @@ namespace MN.L10n.NullProviders
 			};
 		}
 
-        public Task LoadTranslationFromSources(L10n l10n, CancellationToken token)
+        public Task<bool> LoadTranslationFromSources(L10n l10n, CancellationToken token)
         {
-            throw new System.NotImplementedException();
+	        return Task.FromResult(false);
         }
 
         public bool SaveL10n(L10n l10n)


### PR DESCRIPTION
Implemented ReloadFromSources in null data provider (as noop).
Added method to remove all translation reloaded listeneres. (Needed for tests)