### PR TITLE
Typescript, disallow dynamic strings

### DIFF
--- a/MN.L10n.Javascript/Javascript/package.json
+++ b/MN.L10n.Javascript/Javascript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multinet/mn-l10n",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "Multinet translation library",
   "main": "dist/L10n.js",
   "types": "dist/types",

--- a/MN.L10n.Javascript/Javascript/src/publicTypes.d.ts
+++ b/MN.L10n.Javascript/Javascript/src/publicTypes.d.ts
@@ -20,10 +20,14 @@ type InvalidEmptyStringResult = never;
 declare global {
   function _s(l10nString: ""): InvalidEmptyStringResult;
   function _s<T extends string>(
-    l10nString: StringWithoutFormatArgs<T>
+    l10nString: string extends T ? never : StringWithoutFormatArgs<T>
   ): TranslatedString;
   function _s<T extends string>(
-    l10nString: T extends StringWithoutFormatArgs<T> ? never : T,
+    l10nString: string extends T
+      ? never
+      : T extends StringWithoutFormatArgs<T>
+      ? never
+      : T,
     formatParameters: {
       [key in ExtractL10nParameter<T>]: string | number;
     }

--- a/MN.L10n.Javascript/Javascript/src/publicTypes.d.ts
+++ b/MN.L10n.Javascript/Javascript/src/publicTypes.d.ts
@@ -15,12 +15,13 @@ export type TranslatedString = string & {
   readonly __l10nuid__: never;
 };
 
-type InvalidEmptyStringResult = never;
-
 declare global {
-  function _s(l10nString: ""): InvalidEmptyStringResult;
   function _s<T extends string>(
-    l10nString: string extends T ? never : StringWithoutFormatArgs<T>
+    l10nString: string extends T
+      ? never
+      : "" extends T
+      ? never
+      : StringWithoutFormatArgs<T>
   ): TranslatedString;
   function _s<T extends string>(
     l10nString: string extends T


### PR DESCRIPTION
Calling _s in typescript with a dynamic value in typescript will now give an error, the error isn't especially clear but unfortunately typescript has no current support for error values so this is the best one can do.

Also changed the typing for _s("") to give the same error.

![image](https://user-images.githubusercontent.com/5786561/156536533-21e33fa7-0b38-4993-a0c7-18cb4c46e2c6.png)

