### PR TITLE
Feat: download translation argument (usable both in global tool and buildtask)

### DIFF
--- a/MN.L10n.Analyzer/MN.L10n.Analyzer.Test/MN.L10n.Analyzer.Test.csproj
+++ b/MN.L10n.Analyzer/MN.L10n.Analyzer.Test/MN.L10n.Analyzer.Test.csproj
@@ -5,10 +5,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.10" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.10" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/MN.L10n.Analyzer/MN.L10n.Analyzer/MN.L10n.Analyzer.csproj
+++ b/MN.L10n.Analyzer/MN.L10n.Analyzer/MN.L10n.Analyzer.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.8.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.2.0" PrivateAssets="all" />
     <PackageReference Update="NETStandard.Library" PrivateAssets="all" />
   </ItemGroup>
 

--- a/MN.L10n.BuildTasks/Program.cs
+++ b/MN.L10n.BuildTasks/Program.cs
@@ -129,7 +129,7 @@ namespace MN.L10n.BuildTasks
                     new FileDataProvider(solutionDir)
                 );
 
-                if (config.DownloadTranslationFromSourcesOnBuild)
+                if (config.DownloadTranslationFromSourcesOnBuild || args.Contains("--download-translations"))
                 {
                     Console.WriteLine("info l10n: Loading translations from sources defined in languages.json");
                     var fdp = L10n.GetDataProvider();

--- a/MN.L10n.BuildTasks/Program.cs
+++ b/MN.L10n.BuildTasks/Program.cs
@@ -145,6 +145,12 @@ namespace MN.L10n.BuildTasks
                             Console.WriteLine("info l10n: {0}", tce.ToString());
                         }
                     }
+
+                    if (args.Contains("--download-translations"))
+                    {
+                        Console.WriteLine("info l10n: Translations downloaded, exiting");
+                        return 0;
+                    }
                 }
 
                 var validExtensions = new[] { ".aspx", ".ascx", ".js", ".jsx", ".cs", ".cshtml", ".ts", ".tsx", ".master", ".ashx", ".php" };

--- a/MN.L10n.Javascript.Core/MN.L10n.Javascript.Core.csproj
+++ b/MN.L10n.Javascript.Core/MN.L10n.Javascript.Core.csproj
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Http.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MN.L10n.Mvc/MN.L10n.Mvc.csproj
+++ b/MN.L10n.Mvc/MN.L10n.Mvc.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.7" />
+    <PackageReference Include="Microsoft.AspNet.Mvc" Version="5.2.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MN.L10n.Tests/MN.L10n.Tests.csproj
+++ b/MN.L10n.Tests/MN.L10n.Tests.csproj
@@ -6,13 +6,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="6.2.1" />
-    <PackageReference Include="coverlet.collector" Version="3.0.3">
+    <PackageReference Include="FakeItEasy" Version="7.3.1" />
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.4.1" />
   </ItemGroup>
 

--- a/MN.L10n/MN.L10n.csproj
+++ b/MN.L10n/MN.L10n.csproj
@@ -34,8 +34,8 @@ Translation package</Description>
   <ItemGroup>
 	<PackageReference Include="CommonMark.NET" Version="0.15.1" />
 	<PackageReference Include="Microsoft.AspNetCore.Html.Abstractions" Version="2.2.0" />
-	<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-	<PackageReference Include="NGettext" Version="0.6.6" />
+	<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+	<PackageReference Include="NGettext" Version="0.6.7" />
 	<!--<PackageReference Update="@(PackageReference)" PrivateAssets="All" />-->
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
## Features
- If you add `--download-translations` to the global tool/buildtask as an argument, you will _only_ download translations, no additional parsing will be done.
  Fixes #115

## Package upgrades
- Upgraded a lot of packages, to get rid of some security flaws and warnings