### PR TITLE
Added a flag to FileDataProvider to prevent it from writing to disk.

### DIFF
--- a/MN.L10n/FileProviders/FileDataProvider.cs
+++ b/MN.L10n/FileProviders/FileDataProvider.cs
@@ -22,6 +22,8 @@ namespace MN.L10n.FileProviders
         private string PhraseFile { get; set; }
         private string LanguagesFile { get; set; }
         private string LanguageFile { get; set; }
+        public bool SaveChangesToDisk { get; set; } = true;
+        
         public FileDataProvider(string path, string l10nFileName = "phrases.json", string l10nPhraseFileNameFormat = "language-{0}.json", string l10nLanguagesFileName = "languages.json")
         {
             FilePath = path;
@@ -61,7 +63,7 @@ namespace MN.L10n.FileProviders
                         languages.Add(new L10nLanguageItem { LanguageId = locLang });
                     }
 
-                    File.WriteAllText(langPath, JsonConvert.SerializeObject(languages, SerializerOptions));
+                    WriteToDiskIfAllowed(langPath, JsonConvert.SerializeObject(languages, SerializerOptions));
                 }
             }
 
@@ -80,7 +82,7 @@ namespace MN.L10n.FileProviders
                 {
                     Languages = languages
                 };
-                File.WriteAllText(phrasePath, JsonConvert.SerializeObject(l10n, SerializerOptions));
+                WriteToDiskIfAllowed(phrasePath, JsonConvert.SerializeObject(l10n, SerializerOptions));
 
                 return l10n;
             }
@@ -109,7 +111,7 @@ namespace MN.L10n.FileProviders
                         PluralizationRules = new List<string> { "0", "1" },
                         PluralRule = "n != 1"
                     };
-                    File.WriteAllText(langFileName, JsonConvert.SerializeObject(nLang, SerializerOptions));
+                    WriteToDiskIfAllowed(langFileName, JsonConvert.SerializeObject(nLang, SerializerOptions));
                     l10n.LanguagePhrases.TryAdd(lang, nLang);
                 }
 
@@ -129,7 +131,7 @@ namespace MN.L10n.FileProviders
         public bool SaveL10n(L10n l10n)
         {
             var l10nFileContents = JsonConvert.SerializeObject(l10n, SerializerOptions);
-            File.WriteAllText(Path.Combine(FilePath, PhraseFile), l10nFileContents);
+            WriteToDiskIfAllowed(Path.Combine(FilePath, PhraseFile), l10nFileContents);
 
             SaveTranslation(l10n);
 
@@ -204,7 +206,7 @@ namespace MN.L10n.FileProviders
                     }
 
                     var langFileName = Path.Combine(FilePath, string.Format(LanguageFile, lang.LanguageId));
-                    File.WriteAllText(langFileName, JsonConvert.SerializeObject(l10nLang, SerializerOptions));
+                    WriteToDiskIfAllowed(langFileName, JsonConvert.SerializeObject(l10nLang, SerializerOptions));
 
                     if (token.IsCancellationRequested)
                     {
@@ -225,10 +227,18 @@ namespace MN.L10n.FileProviders
                 var l10nLang = l10n.LanguagePhrases[lang.LanguageId];
 
                 var langFileName = Path.Combine(FilePath, string.Format(LanguageFile, lang.LanguageId));
-                File.WriteAllText(langFileName, JsonConvert.SerializeObject(l10nLang, SerializerOptions));
+                WriteToDiskIfAllowed(langFileName, JsonConvert.SerializeObject(l10nLang, SerializerOptions));
             }
 
             return true;
+        }
+
+        private void WriteToDiskIfAllowed(string pathAndFilename, string contents)
+        {
+            if (SaveChangesToDisk)
+            {
+                File.WriteAllText(pathAndFilename, contents);
+            }
         }
     }
 }

--- a/MN.L10n/MN.L10n.csproj
+++ b/MN.L10n/MN.L10n.csproj
@@ -12,13 +12,13 @@ Translation package</Description>
 		<PackageProjectUrl>https://github.com/MultinetInteractive/MN.L10n</PackageProjectUrl>
 		<RepositoryType>git</RepositoryType>
 		<Copyright>© 20XX MultiNet Interactive AB</Copyright>
-		<Version>3.0.0</Version>
+		<Version>3.0.1-beta.1</Version>
 	<AutoIncrementPackageRevision>True</AutoIncrementPackageRevision>
 	<PackageReleaseNotes>Now includes analyzer</PackageReleaseNotes>
 	<ApplicationIcon />
 	<OutputType>Library</OutputType>
 	<StartupObject></StartupObject>
-	<AssemblyVersion>3.0.0</AssemblyVersion>
+	<AssemblyVersion>3.0.1</AssemblyVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
The intended use for this is to download new translations on app-start when running locally. 
Doing that currently can cause unintended changes since the language files are version-controlled in some of our repositories.