### PR TITLE
JavascriptTranslationMiddleware, added a solution to make caching safer

### DIFF
--- a/MN.L10n.JavascriptTranslationMiddleware/Configuration/JavascriptTranslationMiddlewareConfiguration.cs
+++ b/MN.L10n.JavascriptTranslationMiddleware/Configuration/JavascriptTranslationMiddlewareConfiguration.cs
@@ -10,6 +10,7 @@ namespace MN.L10n.JavascriptTranslationMiddleware
         string CompiledFolder { get; }
         Func<HttpContext, FileHandle, Task<bool>> ShouldTranslateAsync { get; }
         Func<HttpContext, Task<bool>> EnableCacheAsync { get; }
+        VersionedFileRedirectConfig? VersionedFileRedirectConfig { get; }
     }
 
     internal class JavascriptTranslationMiddlewareConfiguration : IJavascriptTranslationMiddlewareConfiguration
@@ -18,6 +19,7 @@ namespace MN.L10n.JavascriptTranslationMiddleware
         public string CompiledFolder { get; }
         public Func<HttpContext, FileHandle, Task<bool>> ShouldTranslateAsync { get; set; } = (_, _) => Task.FromResult(true);
         public Func<HttpContext, Task<bool>> EnableCacheAsync { get; set; } = _ => Task.FromResult(true);
+        public VersionedFileRedirectConfig? VersionedFileRedirectConfig { get; set; }
 
         public JavascriptTranslationMiddlewareConfiguration(PathString[] requestPathPrefixes, string compiledFolder)
         {

--- a/MN.L10n.JavascriptTranslationMiddleware/Configuration/VersionedFileRedirectConfig.cs
+++ b/MN.L10n.JavascriptTranslationMiddleware/Configuration/VersionedFileRedirectConfig.cs
@@ -1,0 +1,16 @@
+using System;
+using Microsoft.AspNetCore.Http;
+
+namespace MN.L10n.JavascriptTranslationMiddleware;
+
+public class VersionedFileRedirectConfig
+{
+    public int? MaxAge { get; set; } = 60 * 30;
+    public int? StaleWhileRevalidate { get; set; } = 60 * 60 * 24 * 7;
+    /// <summary>
+    /// Allows the user to override the Cache-Control max-age by using a query parameter on the referer level.
+    /// Intended for debugging.
+    /// </summary>
+    public string? RefererMaxAgeOverrideParameterName = "_l10ntsMaxAge";
+    public Action<HttpContext>? OnRedirect { get; set; }
+}

--- a/MN.L10n.JavascriptTranslationMiddleware/FileTranslatorProvider.cs
+++ b/MN.L10n.JavascriptTranslationMiddleware/FileTranslatorProvider.cs
@@ -7,24 +7,29 @@ namespace MN.L10n.JavascriptTranslationMiddleware
     {
         FileTranslator GetOrCreateTranslator(string languageId, IFileHandle fileHandle);
     }
-    
+
     public class FileTranslatorProvider : ITranslatorProvider
     {
         private readonly ConcurrentDictionary<string, FileTranslator> _fileProviders = new();
         private readonly IJavascriptTranslationL10nLanguageProvider _l10NLanguageProvider;
         private readonly ILogger<FileTranslator> _logger;
+        private readonly IJavascriptTranslationMiddlewareConfiguration _configuration;
 
-        public FileTranslatorProvider(IJavascriptTranslationL10nLanguageProvider l10NLanguageProvider, ILogger<FileTranslator> logger)
+        public FileTranslatorProvider(IJavascriptTranslationL10nLanguageProvider l10NLanguageProvider,
+            ILogger<FileTranslator> logger, IJavascriptTranslationMiddlewareConfiguration configuration)
         {
             _l10NLanguageProvider = l10NLanguageProvider;
             _logger = logger;
+            _configuration = configuration;
         }
 
         public FileTranslator GetOrCreateTranslator(string languageId, IFileHandle fileHandle)
         {
             var fileProviderId = $"{languageId}__{fileHandle.RelativeRequestPath}";
-            
-            return _fileProviders.GetOrAdd(fileProviderId, _ => new FileTranslator(_l10NLanguageProvider, fileHandle, languageId, _logger));
+
+            return _fileProviders.GetOrAdd(fileProviderId,
+                _ => new FileTranslator(_l10NLanguageProvider, fileHandle, languageId, _logger,
+                    enableFileVersionGeneration: _configuration.VersionedFileRedirectConfig != null));
         }
     }
 }

--- a/MN.L10n.JavascriptTranslationMiddleware/MN.L10n.JavascriptTranslationMiddleware.csproj
+++ b/MN.L10n.JavascriptTranslationMiddleware/MN.L10n.JavascriptTranslationMiddleware.csproj
@@ -1,15 +1,16 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-      <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+      <TargetFramework>net7.0</TargetFramework>
       <Nullable>Enable</Nullable>
       <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-      <PackageVersion>1.0.4</PackageVersion>
+      <PackageVersion>2.0.0</PackageVersion>
       <Authors>lice, chbe, chga</Authors>
       <RepositoryUrl>https://github.com/MultinetInteractive/MN.L10n</RepositoryUrl>
       <Copyright>© 20XX MultiNet Interactive AB</Copyright>
       <PackageProjectUrl>https://github.com/MultinetInteractive/MN.L10n</PackageProjectUrl>
       <RepositoryType>git</RepositoryType>
+      <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/MN.L10n.Tests/JavascriptTranslationMiddleware/TranslatedFileProviderTests.cs
+++ b/MN.L10n.Tests/JavascriptTranslationMiddleware/TranslatedFileProviderTests.cs
@@ -101,7 +101,7 @@ namespace MN.L10n.Tests.JavascriptTranslationMiddleware
             };
 
             var fakes = new Fakes(language);
-            var translator = new FileTranslator(fakes.LanguageProvider, fakes.FileHandle, languageId, fakes.Logger);
+            var translator = new FileTranslator(fakes.LanguageProvider, fakes.FileHandle, languageId, fakes.Logger, true);
 
             L10nLanguage tmp;
             A.CallTo(() => fakes.LanguageProvider.TryGetLanguage(languageId, out tmp))

--- a/MN.L10n.Tests/MN.L10n.Tests.csproj
+++ b/MN.L10n.Tests/MN.L10n.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
     <PackageReference Include="FakeItEasy" Version="7.4.0" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Currently we cache all files that go through the JavascriptTranslationMiddleware permanently since their filenames contain a content hash. This is incorrect if we change the translations without updating the source code. The new version of the JavascriptTranslationMiddleware uses an extra level of redirects to improve this (on by default, but configurable).

Instead of directly returning the translated file it instead returns a redirect to the same path but with a contenthash based on the translated filecontents in a queryparameter. This makes it safe to cache the result of the url with the queryparameter permanently. By default we also cache the redirect for 30 minutes (configurable) with a fairly high revalidate-while-stale header (also configurable). The first level of caching still makes it possible for clients to have stale translations for a bit but nowhere near as long as our current solution.

The reason for the extra redirect with the hashed filecontents on the url instead of just returning a fairly short max-age and a fairly long revalidate-while-stale header from the top-level is because revalidate-while-stale isn't supported in all browsers (Safari) and this would cause many unnecessary requests.