### PR TITLE
Better support for phrases which contain a \n

### DIFF
--- a/MN.L10n.BuildTasks/MN.L10n.BuildTasks.csproj
+++ b/MN.L10n.BuildTasks/MN.L10n.BuildTasks.csproj
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <StartupObject>MN.L10n.BuildTasks.Program</StartupObject>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.0.0</Version>
+    <Version>4.0.1</Version>
     <Authors>Chris Gårdenberg</Authors>
     <Company>MultiNet Interactive AB</Company>
   </PropertyGroup>

--- a/MN.L10n.Javascript.Core/MN.L10n.Javascript.Core.csproj
+++ b/MN.L10n.Javascript.Core/MN.L10n.Javascript.Core.csproj
@@ -7,7 +7,7 @@
     <PackageProjectUrl>https://github.com/MultinetInteractive/MN.L10n</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <Copyright>© 20XX MultiNet Interactive AB</Copyright>
-    <Version>3.0.1</Version>
+    <Version>3.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MN.L10n.Javascript.Shared/MN.L10n.Javascript.Shared.csproj
+++ b/MN.L10n.Javascript.Shared/MN.L10n.Javascript.Shared.csproj
@@ -7,7 +7,7 @@
     <PackageProjectUrl>https://github.com/MultinetInteractive/MN.L10n</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <Copyright>© 20XX MultiNet Interactive AB</Copyright>
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
     <AutoIncrementPackageRevision>True</AutoIncrementPackageRevision>
   </PropertyGroup>
 

--- a/MN.L10n.Javascript/MN.L10n.Javascript.csproj
+++ b/MN.L10n.Javascript/MN.L10n.Javascript.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFrameworks>net48</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.0.0</Version>
-    <AssemblyVersion>2.0.0.0</AssemblyVersion>
+    <Version>2.0.1</Version>
+    <AssemblyVersion>2.0.0.1</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MN.L10n.Tests/ParserTests.cs
+++ b/MN.L10n.Tests/ParserTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.IO;
+using System.Linq;
 using Xunit;
 
 namespace MN.L10n.Tests
@@ -104,6 +105,27 @@ Ni kan också kontakta oss på <a href=""""https://support.semesterlistan.se""""
             var parser = new L10nParser();
             var result = parser.Parse(src);
             Assert.Single(result);
+        }
+        
+        [Fact]
+        public void FulTest()
+        {
+            var src = File.ReadAllText(
+                "D:\\git\\dm\\avtalshantering.app\\Scripts\\Webpack\\React\\Pages\\Settings\\Resources\\Tabs\\EditCompanyNotificationSettings.tsx");
+            
+            var parser = new L10nParser();
+            var result = parser.Parse(src).ToArray();
+            
+            Assert.Equal("Följande inställningar gäller som standard för nya användare.\nAnvändare kan välja vilka notifikationer de vill få under \"Mina inställningar\".", result[2].Phrase);
+        }
+
+        [Fact]
+        public void LineBreakCharInCall()
+        {
+            var parser = new L10nParser();
+            var result = parser.Parse("_s('Hello\\nBrother')");
+
+            Assert.Collection(result, x => Assert.Equal("Hello\nBrother", x.Phrase));
         }
     }
 }

--- a/MN.L10n.Tests/ParserTests.cs
+++ b/MN.L10n.Tests/ParserTests.cs
@@ -106,18 +106,6 @@ Ni kan också kontakta oss på <a href=""""https://support.semesterlistan.se""""
             var result = parser.Parse(src);
             Assert.Single(result);
         }
-        
-        [Fact]
-        public void FulTest()
-        {
-            var src = File.ReadAllText(
-                "D:\\git\\dm\\avtalshantering.app\\Scripts\\Webpack\\React\\Pages\\Settings\\Resources\\Tabs\\EditCompanyNotificationSettings.tsx");
-            
-            var parser = new L10nParser();
-            var result = parser.Parse(src).ToArray();
-            
-            Assert.Equal("Följande inställningar gäller som standard för nya användare.\nAnvändare kan välja vilka notifikationer de vill få under \"Mina inställningar\".", result[2].Phrase);
-        }
 
         [Fact]
         public void LineBreakCharInCall()

--- a/MN.L10n/L10nParser.cs
+++ b/MN.L10n/L10nParser.cs
@@ -181,7 +181,15 @@ namespace MN.L10n
                                 }
                             }
 
-                            _tokenContent.Append(source[_pos]);
+                            if (inToken && !isVerbatim && source[_pos] == '\\' && TryPeek(1) && source[_pos + 1] == 'n')
+                            {
+                                _pos++;
+                                _tokenContent.Append('\n');
+                            }
+                            else
+                            {
+                                _tokenContent.Append(source[_pos]);
+                            }
                         }
                         break;
                 }

--- a/MN.L10n/MN.L10n.csproj
+++ b/MN.L10n/MN.L10n.csproj
@@ -12,13 +12,13 @@ Translation package</Description>
 		<PackageProjectUrl>https://github.com/MultinetInteractive/MN.L10n</PackageProjectUrl>
 		<RepositoryType>git</RepositoryType>
 		<Copyright>© 20XX MultiNet Interactive AB</Copyright>
-		<Version>4.0.0</Version>
+		<Version>4.0.1</Version>
 	<AutoIncrementPackageRevision>True</AutoIncrementPackageRevision>
 	<PackageReleaseNotes>Now includes analyzer</PackageReleaseNotes>
 	<ApplicationIcon />
 	<OutputType>Library</OutputType>
 	<StartupObject></StartupObject>
-	<AssemblyVersion>4.0.0</AssemblyVersion>
+	<AssemblyVersion>4.0.1</AssemblyVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Currently if you call _s with \n inside the phrase the parser interprets that as a backslash followed by an n. This fixes that.