### PR TITLE
Fixed issues with escaped strings inside the phrase

### DIFF
--- a/MN.L10n.Tests/ParserTests.cs
+++ b/MN.L10n.Tests/ParserTests.cs
@@ -115,5 +115,32 @@ Ni kan också kontakta oss på <a href=""""https://support.semesterlistan.se""""
 
             Assert.Collection(result, x => Assert.Equal("Hello\nBrother", x.Phrase));
         }
+
+        [Fact]
+        public void TestEscapedStringContainerCharacter()
+        {
+            var parser = new L10nParser();
+            var result = parser.Parse(@"_s(""Hello \""friend\"". How it do?"")");
+
+            Assert.Collection(result, x => Assert.Equal(@"Hello ""friend"". How it do?", x.Phrase));            
+        }
+        
+        [Fact]
+        public void TestEscapedStringContainerCharacter2()
+        {
+            var parser = new L10nParser();
+            var result = parser.Parse(@"_s('Hello \""friend\"". How it do?')");
+
+            Assert.Collection(result, x => Assert.Equal(@"Hello \""friend\"". How it do?", x.Phrase));            
+        }
+        
+        [Fact]
+        public void TestEscapedStringContainerCharacter3()
+        {
+            var parser = new L10nParser();
+            var result = parser.Parse(@"_s('Hello \'friend\'. How it do?')");
+
+            Assert.Collection(result, x => Assert.Equal(@"Hello 'friend'. How it do?", x.Phrase));            
+        }
     }
 }

--- a/MN.L10n/L10nParser.cs
+++ b/MN.L10n/L10nParser.cs
@@ -181,10 +181,17 @@ namespace MN.L10n
                                 }
                             }
 
-                            if (inToken && !isVerbatim && source[_pos] == '\\' && TryPeek(1) && source[_pos + 1] == 'n')
+                            if (inToken && !isVerbatim && source[_pos] == '\\' && TryPeek(1) && (source[_pos + 1] == 'n' || source[_pos + 1] == _stringContainer))
                             {
+                                if (source[_pos + 1] == 'n')
+                                {
+                                    _tokenContent.Append('\n');
+                                }
+                                else if (source[_pos + 1] == _stringContainer)
+                                {
+                                    _tokenContent.Append(_stringContainer);
+                                }
                                 _pos++;
-                                _tokenContent.Append('\n');
                             }
                             else
                             {


### PR DESCRIPTION
We've had issues with phrases that looks like this 
```cs
_s("\"Byt artikel\" listar artiklar direkt")
```
 since the quotes will be escaped in the source. But the backslash escaping the quote should not be a part of the phrase to translate in and of itself. This is very similar to the issue with newlines we fixed here https://github.com/MultinetInteractive/MN.L10n/pull/176

I could add more cases (for instance \t) but this is the only one I know we actually use