### PR TITLE
fix: Remove \r from js template strings

### DIFF
--- a/MN.L10n.BuildTasks/MN.L10n.BuildTasks.csproj
+++ b/MN.L10n.BuildTasks/MN.L10n.BuildTasks.csproj
@@ -6,7 +6,7 @@
     <OutputType>Exe</OutputType>
     <StartupObject>MN.L10n.BuildTasks.Program</StartupObject>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>4.0.4</Version>
+    <Version>4.0.5</Version>
     <Authors>Chris Gårdenberg</Authors>
     <Company>MultiNet Interactive AB</Company>
   </PropertyGroup>

--- a/MN.L10n.Tests/ParserTests.cs
+++ b/MN.L10n.Tests/ParserTests.cs
@@ -166,5 +166,15 @@ Nej""
             Assert.Single(result);
             Assert.Equal(@"Hej ""bror""\nNej", result[0].Phrase.Trim());
         }
+        
+        [Fact]
+        public void TestNewlineInJsTemplateString()
+        {
+            var src = "_s(`Hello\r\nbrother!`)";
+            var parser = new L10nParser();
+            var result = parser.Parse(src).ToList();
+            Assert.Single(result);
+            Assert.Equal("Hello\nbrother!", result[0].Phrase.Trim());
+        }
     }
 }

--- a/MN.L10n/L10nParser.cs
+++ b/MN.L10n/L10nParser.cs
@@ -209,6 +209,12 @@ namespace MN.L10n
             }
             else
             {
+                if (phraseInvocation.StringContainer == '`')
+                {
+                    phraseInvocation.Phrase = phraseInvocation.Phrase
+                        .Replace("\r", "");
+                }
+                
                 for (var i = 0; i < phraseInvocation.Phrase.Length; i++)
                 {
                     if (phraseInvocation.Phrase[i] == '\\' && i + 1 < phraseInvocation.Phrase.Length)

--- a/MN.L10n/MN.L10n.csproj
+++ b/MN.L10n/MN.L10n.csproj
@@ -12,14 +12,14 @@ Translation package</Description>
 		<PackageProjectUrl>https://github.com/MultinetInteractive/MN.L10n</PackageProjectUrl>
 		<RepositoryType>git</RepositoryType>
 		<Copyright>© 20XX MultiNet Interactive AB</Copyright>
-		<Version>4.1.3</Version>
+		<Version>4.1.4</Version>
         <LangVersion>latest</LangVersion>
 	<AutoIncrementPackageRevision>True</AutoIncrementPackageRevision>
 	<PackageReleaseNotes>Now includes analyzer</PackageReleaseNotes>
 	<ApplicationIcon />
 	<OutputType>Library</OutputType>
 	<StartupObject></StartupObject>
-	<AssemblyVersion>4.1.3</AssemblyVersion>
+	<AssemblyVersion>4.1.4</AssemblyVersion>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
This seems to be required for the string to match runtime. 
This is similar to how we handle verbatim strings in c#